### PR TITLE
Add macOS/Xcode to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ matrix:
         - ./flutter/bin/flutter doctor
       script:
         - ./flutter/bin/flutter test
+        - ./flutter/bin/flutter -v build ios
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,7 @@ matrix:
         - ./flutter/bin/flutter doctor
       script:
         - ./flutter/bin/flutter test
-        # TODO(yjbanov): enable this after figuring out provisioning pofiles
-        # - ./flutter/bin/flutter -v build ios
+        - ./flutter/bin/flutter -v build ios --no-codesign
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,11 @@ matrix:
       language: generic
       osx_image: xcode8.3
       before_script:
+        - pip install six
+        - brew update
+        - brew install --HEAD libimobiledevice
+        - brew install ideviceinstaller
+        - brew install ios-deploy
         - ./travis_setup.sh
         - ./flutter/bin/flutter doctor
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ jdk:
   - oraclejdk8
 os:
   - linux
+  - osx
+osx_image: xcode8.3
 sudo: false
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,8 @@ matrix:
         - ./flutter/bin/flutter doctor
       script:
         - ./flutter/bin/flutter test
-        - ./flutter/bin/flutter -v build ios
+        # TODO(yjbanov): enable this after figuring out provisioning pofiles
+        # - ./flutter/bin/flutter -v build ios
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,35 @@
 language: android
-licenses:
-    - 'android-sdk-preview-license-.+'
-    - 'android-sdk-license-.+'
-    - 'google-gdk-license-.+'
-android:
-  components:
-    - tools
-    - platform-tools
-    - build-tools-25.0.3
-    - android-25
-    - sys-img-armeabi-v7a-google_apis-25
-    - extra-android-m2repository
-    - extra-google-m2repository
-    - extra-google-android-support
-jdk:
-  - oraclejdk8
-os:
-  - linux
-  - osx
-osx_image: xcode8.3
-sudo: false
-addons:
-  apt:
-    # Flutter depends on /usr/lib/x86_64-linux-gnu/libstdc++.so.6 version GLIBCXX_3.4.18
-    sources:
-      - ubuntu-toolchain-r-test # if we don't specify this, the libstdc++6 we get is the wrong version
-    packages:
-      - libstdc++6
-      - fonts-droid
+
+matrix:
+  include:
+    - os: linux
+      licenses:
+        - 'android-sdk-preview-license-.+'
+        - 'android-sdk-license-.+'
+        - 'google-gdk-license-.+'
+      android:
+        components:
+          - tools
+          - platform-tools
+          - build-tools-25.0.3
+          - android-25
+          - sys-img-armeabi-v7a-google_apis-25
+          - extra-android-m2repository
+          - extra-google-m2repository
+          - extra-google-android-support
+      jdk: oraclejdk8
+      sudo: false
+      addons:
+        apt:
+          # Flutter depends on /usr/lib/x86_64-linux-gnu/libstdc++.so.6 version GLIBCXX_3.4.18
+          sources:
+            - ubuntu-toolchain-r-test # if we don't specify this, the libstdc++6 we get is the wrong version
+          packages:
+            - libstdc++6
+            - fonts-droid
+    - os: osx
+      osx_image: xcode8.3
+
 before_script:
   - wget http://services.gradle.org/distributions/gradle-3.5-bin.zip
   - unzip -qq gradle-3.5-bin.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
-language: android
-
 matrix:
   include:
     - os: linux
+      language: android
       licenses:
         - 'android-sdk-preview-license-.+'
         - 'android-sdk-license-.+'
@@ -27,26 +26,33 @@ matrix:
           packages:
             - libstdc++6
             - fonts-droid
-    - os: osx
-      osx_image: xcode8.3
+      before_script:
+        - wget http://services.gradle.org/distributions/gradle-3.5-bin.zip
+        - unzip -qq gradle-3.5-bin.zip
+        - export GRADLE_HOME=$PWD/gradle-3.5
+        - export PATH=$GRADLE_HOME/bin:$PATH
+        - gradle -v
+        - android list targets
+        - ./travis_setup.sh
+        - echo no | android create avd --force -n test -t android-25 --abi armeabi-v7a --tag google_apis
+      #  - emulator -avd test -no-audio -no-window &
+      #  - android-wait-for-emulator
+      #  - adb shell input keyevent 82 &
+        - ./flutter/bin/flutter doctor
+      script:
+        - ./flutter/bin/flutter test
+      #  - ./flutter/bin/flutter -v run --trace-startup --no-hot
+        - ./flutter/bin/flutter -v build apk
 
-before_script:
-  - wget http://services.gradle.org/distributions/gradle-3.5-bin.zip
-  - unzip -qq gradle-3.5-bin.zip
-  - export GRADLE_HOME=$PWD/gradle-3.5
-  - export PATH=$GRADLE_HOME/bin:$PATH
-  - gradle -v
-  - android list targets
-  - ./travis_setup.sh
-  - echo no | android create avd --force -n test -t android-25 --abi armeabi-v7a --tag google_apis
-#  - emulator -avd test -no-audio -no-window &
-#  - android-wait-for-emulator
-#  - adb shell input keyevent 82 &
-  - ./flutter/bin/flutter doctor
-script:
-  - ./flutter/bin/flutter test
-#  - ./flutter/bin/flutter -v run --trace-startup --no-hot
-  - ./flutter/bin/flutter -v build apk
+    - os: osx
+      language: generic
+      osx_image: xcode8.3
+      before_script:
+        - ./travis_setup.sh
+        - ./flutter/bin/flutter doctor
+      script:
+        - ./flutter/bin/flutter test
+
 cache:
   directories:
     - $HOME/.pub-cache


### PR DESCRIPTION
This creates a build matrix of two jobs: a Linux job building for Android and a macOS job building for iOS.

@lukef @alardizabal 
