### PR TITLE
Fast PR build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,17 @@
 matrix:
+  # This causes the build to complete immediately upon first failure or once
+  # required jobs are green.
+  fast_finish: true
+
+  # Building APK/IPA takes a long time; do not wait for them to finish.
+  allow_failures:
+    - env: JOB=APK
+    - env: JOB=IPA
+
   include:
-    - os: linux
+    # Runs unit tests without emulators.
+    - env: JOB=PR
+      os: linux
       language: generic
       sudo: false
       addons:
@@ -17,7 +28,9 @@ matrix:
       script:
         - ./flutter/bin/flutter test
 
-    - os: linux
+    # Builds an APK.
+    - env: JOB=APK
+      os: linux
       language: android
       licenses:
         - 'android-sdk-preview-license-.+'
@@ -57,11 +70,12 @@ matrix:
       #  - adb shell input keyevent 82 &
         - ./flutter/bin/flutter doctor
       script:
-        - ./flutter/bin/flutter test
       #  - ./flutter/bin/flutter -v run --trace-startup --no-hot
         - ./flutter/bin/flutter -v build apk
 
-    - os: osx
+    # Builds an IPA.
+    - env: JOB=IPA
+      os: osx
       language: generic
       osx_image: xcode8.3
       before_script:
@@ -73,7 +87,6 @@ matrix:
         - ./travis_setup.sh
         - ./flutter/bin/flutter doctor
       script:
-        - ./flutter/bin/flutter test
         - ./flutter/bin/flutter -v build ios --no-codesign
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,23 @@
 matrix:
   include:
     - os: linux
+      language: generic
+      sudo: false
+      addons:
+        apt:
+          # Flutter depends on /usr/lib/x86_64-linux-gnu/libstdc++.so.6 version GLIBCXX_3.4.18
+          sources:
+            - ubuntu-toolchain-r-test # if we don't specify this, the libstdc++6 we get is the wrong version
+          packages:
+            - libstdc++6
+            - fonts-droid
+      before_script:
+        - ./travis_setup.sh
+        - ./flutter/bin/flutter doctor
+      script:
+        - ./flutter/bin/flutter test
+
+    - os: linux
       language: android
       licenses:
         - 'android-sdk-preview-license-.+'


### PR DESCRIPTION
- Create a fast PR build job that only runs Flutter tests w/o Xcode or Android SDKs.
- Make it the only required job in the build
- `allow_failures` on APK/IPA jobs
- Set the `fast_finish` flag on to mark the build as finished as soon as the PR job is finished

Sample run: https://travis-ci.org/flutter/posse_gallery/builds/232585898

@lukef @alardizabal 