### PR TITLE
Category Route Handler

### DIFF
--- a/lib/managers/route_manager.dart
+++ b/lib/managers/route_manager.dart
@@ -34,7 +34,7 @@ class RouteManager {
 
   Handler categoryHandler =
       new Handler(handlerFunc: (_, Map<String, dynamic> params) {
-    String categoryName = params["category"];
+    String categoryName = params["category"][0];
     AppCategory category;
     if (categoryName != null) {
       category = retrieveCategory(categoryName);


### PR DESCRIPTION
The category router handler params["category"] returns a List not a String as expected by the code.
