### PR TITLE
Updated InputDecorator

### DIFF
--- a/lib/managers/route_manager.dart
+++ b/lib/managers/route_manager.dart
@@ -34,7 +34,7 @@ class RouteManager {
 
   Handler categoryHandler =
       new Handler(handlerFunc: (_, Map<String, dynamic> params) {
-    String categoryName = params["category"];
+    String categoryName = params["category"][0];
     AppCategory category;
     if (categoryName != null) {
       category = retrieveCategory(categoryName);

--- a/lib/screens/demos/patterns/check_list_detail.dart
+++ b/lib/screens/demos/patterns/check_list_detail.dart
@@ -131,7 +131,7 @@ class _PatternsListDetailState extends State<PatternsListDetail> {
                 decoration: new InputDecoration(
                   isDense: true,
                   hintText: 'Enter additional details',
-                  hideDivider: true,
+                  border: null,
                 ),
               ),
             ),

--- a/lib/screens/demos/patterns/check_list_screen.dart
+++ b/lib/screens/demos/patterns/check_list_screen.dart
@@ -219,7 +219,7 @@ class _PatternsListState extends State<PatternsList>
                 controller: _controller,
                 decoration: new InputDecoration(
                   hintText: 'Enter your note',
-                  hideDivider: true,
+                  border: null,
                 ),
               ),
             ),


### PR DESCRIPTION
In January 2018 the InputDecorator was completely updated. Check out https://github.com/flutter/flutter/pull/13734 There's a list of incompatible changes. This item in particular relates to this. The hideDivider property has been replaced by border: null